### PR TITLE
Developers: add xLINK contracts documentation (w3)

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -27,6 +27,7 @@
 ## 🎮 Developers
 * [Smart Contracts](developers/contracts/README.md)
   * [btc peg-in endpoint v2-03](developers/contracts/btc-peg-in-endpoint-v2-03.md)
+  * [btc-peg-out-endpoint-v2-01](developers/contracts/btc-peg-out-endpoint-v2-01.md)
   * [meta peg-in endpoint v2-02](developers/contracts/meta-peg-in-endpoint-v2-02.md)
   * [meta peg-out endpoint v2-03](developers/contracts/meta-peg-out-endpoint-v2-03.md)
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -28,6 +28,7 @@
 * [Smart Contracts](developers/contracts/README.md)
   * [btc peg-in endpoint v2-03](developers/contracts/btc-peg-in-endpoint-v2-03.md)
   * [meta peg-in endpoint v2-02](developers/contracts/meta-peg-in-endpoint-v2-02.md)
+  * [meta peg-out endpoint v2-03](developers/contracts/meta-peg-out-endpoint-v2-03.md)
 
 <!-- 
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -30,6 +30,7 @@
   * [btc-peg-out-endpoint-v2-01](developers/contracts/btc-peg-out-endpoint-v2-01.md)
   * [meta peg-in endpoint v2-02](developers/contracts/meta-peg-in-endpoint-v2-02.md)
   * [meta peg-out endpoint v2-03](developers/contracts/meta-peg-out-endpoint-v2-03.md)
+  * [cross-peg-in-endpoint-v2-03](developers/contracts/cross-peg-in-endpoint-v2-03.md)
   * [xlink-staking](developers/contracts/xlink-staking.md)
 
 <!-- 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -31,6 +31,7 @@
   * [meta peg-in endpoint v2-02](developers/contracts/meta-peg-in-endpoint-v2-02.md)
   * [meta peg-out endpoint v2-03](developers/contracts/meta-peg-out-endpoint-v2-03.md)
   * [cross-peg-in-endpoint-v2-03](developers/contracts/cross-peg-in-endpoint-v2-03.md)
+  * [cross-peg-out-endpoint-v2-01](developers/contracts/cross-peg-out-endpoint-v2-01.md)
   * [xlink-staking](developers/contracts/xlink-staking.md)
 
 <!-- 

--- a/developers/contracts/README.md
+++ b/developers/contracts/README.md
@@ -3,3 +3,5 @@
 ## [btc-peg-in-endpoint-v2-03](btc-peg-in-endpoint-v2-03.md)
 
 ## [meta-peg-in-endpoint-v2-02](meta-peg-in-endpoint-v2-02.md)
+
+## [meta-peg-out-endpoint-v2-03](meta-peg-out-endpoint-v2-03.md)

--- a/developers/contracts/README.md
+++ b/developers/contracts/README.md
@@ -2,6 +2,8 @@
 
 ## [btc-peg-in-endpoint-v2-03](btc-peg-in-endpoint-v2-03.md)
 
+## [btc-peg-out-endpoint-v2-01](btc-peg-out-endpoint-v2-01.md)
+
 ## [meta-peg-in-endpoint-v2-02](meta-peg-in-endpoint-v2-02.md)
 
 ## [meta-peg-out-endpoint-v2-03](meta-peg-out-endpoint-v2-03.md)

--- a/developers/contracts/README.md
+++ b/developers/contracts/README.md
@@ -10,4 +10,6 @@
 
 ## [cross-peg-in-endpoint-v2-03](cross-peg-in-endpoint-v2-03.md)
 
+## [cross-peg-out-endpoint-v2-01](cross-peg-out-endpoint-v2-01.md)
+
 ## [xlink-staking](xlink-staking.md)

--- a/developers/contracts/README.md
+++ b/developers/contracts/README.md
@@ -8,4 +8,6 @@
 
 ## [meta-peg-out-endpoint-v2-03](meta-peg-out-endpoint-v2-03.md)
 
+## [cross-peg-in-endpoint-v2-03](cross-peg-in-endpoint-v2-03.md)
+
 ## [xlink-staking](xlink-staking.md)

--- a/developers/contracts/btc-peg-out-endpoint-v2-01.md
+++ b/developers/contracts/btc-peg-out-endpoint-v2-01.md
@@ -1,0 +1,151 @@
+# btc-peg-out-endpoint-v2-01.clar
+
+- Location: `xlink/packages/contracts/bridge-stacks/contracts/btc-peg-out-endpoint-v2-01.clar`
+- [Deployed contract]()
+
+This technical document provides a detailed overview of the contract responsible for managing the peg-out process, enabling the transfer of bridged BTC from the Stacks network back to the Bitcoin network. In this process, aBTC (Bridged BTC tokens on Stacks) is burned or transferred, and BTC is released to a specified Bitcoin address. The contract's primary functionality is implemented through a series of public functions. Let's review this core operation.
+
+
+## Storage
+### `fee-to-address`
+| Data     | Type   |
+| -------- | ------ |
+| Variable | `principal` |
+
+The address where the fees collected from peg-out operations are transferred. By default, this address is the `tx-sender` (the original deployer of the contract).
+
+### `peg-out-paused`
+| Data     | Type   |
+| -------- | ------ |
+| Variable | `bool` |
+
+A flag that indicates whether the peg-out process is active. If set to true, all peg-out operations are paused, preventing any new transactions. The contract is deployed in a paused state by default.
+
+### `peg-out-fee`
+| Data     | Type   |
+| -------- | ------ |
+| Variable | `uint` |
+
+The percentage fee charged for peg-out transactions. By default, this value is `u0`.
+
+### `peg-out-min-fee`
+| Data     | Type   |
+| -------- | ------ |
+| Variable | `uint` |
+
+The minimum fee required for a peg-out transaction, regardless of the transaction amount. By default, this value is `u0`.
+
+## Features
+
+### Peg-out features
+
+#### `request-peg-out-0`
+This function initiates the peg-out process, enabling users to transfer bridged BTC from the Stacks network to a specified Bitcoin address (peg-out-address). First, it validates the requested amount using `validate-peg-out-0` to ensure it meets the minimum requirements (the requested amount must be sufficient to cover both the peg-out fee and the gas fee, leaving a positive net amount available for transfer). The function registers the request by interacting with the `.btc-bridge-registry-v2-01` contract, storing details such as the requesting user, target Bitcoin address, calculated fees, and associated block heights (e.g., `block-height` and `burn-block-height`). A unique request ID is generated for tracking. Finally, the amount of aBTC is escrowed by transferring it from the user to the contract, securing the funds until the request is either completed or revoked.
+
+##### Parameters
+```lisp
+(peg-out-address (buff 128))
+(amount uint)
+```
+
+#### `claim-peg-out`
+This function allows a user to claim a specific peg-out request. The function first retrieves the request details and performs several validations to check that the request is active and valid. It checks that the peg-out process is not paused, the request has not been finalized, revoked, or already claimed, and that all conditions for claiming are met. Upon successful validation, the function registers the request as claimed in the `.btc-bridge-registry-v2-01` contract, updating the state with the claimer's identity, the Bitcoin address (`fulfilled-by`) responsible for completing the transaction, and the block height defining the claim's expiration period. Note that the expiration period defines a specific timeframe during which the claimed request must be finalized. And finally, the updated request details are logged, and the claimer is granted the right to proceed with finalizing the peg-out.
+
+##### Parameters
+```lisp
+(request-id uint)
+(fulfilled-by (buff 128))
+```
+
+#### `finalize-peg-out`
+This function completes the peg-out process. It performs checks to finalize the peg-out, including verifying that the transaction has been mined, and verifies that the included details in the transaction (concerning the amount, recipient address, and fulfiller address) align with the request specifications. The function interacts with the `.btc-bridge-registry-v2-01` contract to mark the request as finalized.
+Additionally, the function processes fees by transferring them to the designated governance address. It then handles the bridged tokens (aBTC) associated with the request in one of two ways:
+1. Approved Peg-in Address:
+    - The tokens are burned, reducing the total supply.
+2. Third-Party Address:
+    - The tokens are transferred from the contract to the claimer, maintaining the total supply.
+
+Once all operations are completed, the function logs the transaction details and confirms the successful finalization of the request.
+
+##### Parameters
+```lisp
+(request-id uint)
+(tx (buff 32768))
+(block { header: (buff 80), height: uint })
+(proof { tx-index: uint, hashes: (list 14 (buff 32)), tree-depth: uint })
+(output-idx uint) 
+(fulfilled-by-idx uint)
+```
+
+#### `revoke-peg-out`
+This function allows the user who created a peg-out request to cancel it, only if certain conditions are met. The function checks that the required `request-revoke-grace-period` has passed since the request was created, and verifies that the request has not already been claimed, finalized, or already revoked. Once these validations are passed, the function updates the request's status to "revoked" in the `.btc-bridge-registry-v2-01` contract. It then processes the refund by transferring the associated fees and the bridged tokens (aBTC) back to the requester.
+
+##### Parameters
+```lisp
+(request-id uint)
+```
+
+### Governance features
+#### `is-dao-or-extension`
+This standard protocol function checks whether a caller (`tx-sender`) is the DAO executor or an authorized extension, delegating the extensions check to the `executor-dao` contract.
+
+#### `is-peg-out-paused`
+A read-only function that checks the operational status of the contract.
+
+#### `pause-peg-out`
+A public function, governed through the `is-dao-or-extension`, that can change the contract's operational status.
+
+##### Parameters
+```lisp
+(paused bool)
+```
+
+### Getters
+
+#### `get-peg-out-fee`
+#### `get-peg-out-min-fee`
+#### `get-request-revoke-grace-period`
+#### `get-request-claim-grace-period`
+#### `get-request-or-fail`
+##### Parameters
+```lisp
+(request-id uint)
+```
+#### `get-peg-in-sent-or-default`
+##### Parameters
+```lisp
+(tx (buff 32768))
+(output uint)
+```
+#### `get-fee-to-address`
+#### `get-txid`
+##### Parameters
+```lisp
+(tx (buff 32768))
+```
+
+## Contract calls (interactions)
+- `executor-dao`: Calls are made to verify whether a certain contract-caller is designated as an extension.
+- `btc-bridge-registry-v2-01`: This contract is called to register, update, and track peg-out requests. 
+- `clarity-bitcoin-v1-07`: This contract is called to validate Bitcoin transactions by verifying that they have been mined and extracting relevant transaction details, such as inputs, outputs, and script data.
+- `token-abtc`: This contract represents the aBTC token on the Stacks network. It is directly responsible for managing the transfer, burning, and refunding of aBTC tokens during the peg-out process.
+
+## Errors
+
+| Error Name       | Value         |
+| ---------------- | ------------- |
+| `err-unauthorised` | `(err u1000)` |
+| `err-paused`    | `(err u1001)` |
+| `err-invalid-amount` | `(err u1003)` |
+| `err-invalid-tx`    | `(err u1004)` |
+| `err-already-sent`   | `(err u1005)` |
+| `err-address-mismatch`   | `(err u1006)` |
+| `err-request-already-revoked`    | `(err u1007)` |
+| `err-request-already-finalized`    | `(err u1008)` |
+| `err-revoke-grace-period`    | `(err u1009)` |
+| `err-request-already-claimed` | `(err u1010)` |
+| `err-bitcoin-tx-not-mined`    | `(err u1011)` |
+| `err-tx-mined-before-request`    | `(err u1013)` |
+| `err-slippage`    | `(err u1016)` |
+
+<!-- Documentation Contract Template v0.1.0 -->

--- a/developers/contracts/btc-peg-out-endpoint-v2-01.md
+++ b/developers/contracts/btc-peg-out-endpoint-v2-01.md
@@ -3,7 +3,7 @@
 - Location: `xlink/packages/contracts/bridge-stacks/contracts/btc-peg-out-endpoint-v2-01.clar`
 - [Deployed contract]()
 
-This technical document provides a detailed overview of the contract responsible for managing the peg-out process, enabling the transfer of bridged BTC from the Stacks network back to the Bitcoin network. In this process, aBTC (Bridged BTC tokens on Stacks) is burned or transferred, and BTC is released to a specified Bitcoin address. The contract's primary functionality is implemented through a series of public functions. Let's review this core operation.
+This technical document provides a detailed overview of the contract responsible for managing the peg-out process, enabling the transfer of bridged BTC from the Stacks network back to the Bitcoin network. In this process, aBTC (Bridged BTC tokens on Stacks) is burned or transferred, depending on the context, and BTC is released to a specified Bitcoin address. The contract's primary functionality is implemented through a series of public functions. Let's review this core operation.
 
 
 ## Storage
@@ -12,7 +12,7 @@ This technical document provides a detailed overview of the contract responsible
 | -------- | ------ |
 | Variable | `principal` |
 
-The address where the fees collected from peg-out operations are transferred. By default, this address is the `tx-sender` (the original deployer of the contract).
+The address where the fees collected from peg-out operations are transferred. By default, the address assigned to receive these fees is the `tx-sender` address of the contract deployer.
 
 ### `peg-out-paused`
 | Data     | Type   |
@@ -26,7 +26,7 @@ A flag that indicates whether the peg-out process is active. If set to true, all
 | -------- | ------ |
 | Variable | `uint` |
 
-The percentage fee charged for peg-out transactions. By default, this value is `u0`.
+The percentage fee charged for peg-out transactions. The fee is represented in a fixed-point format with 6 decimal places. This means that 100% is represented as `u100000000`and 1% is represented as `u1000000`. By default, this value is `u0`.
 
 ### `peg-out-min-fee`
 | Data     | Type   |

--- a/developers/contracts/cross-peg-in-endpoint-v2-03.md
+++ b/developers/contracts/cross-peg-in-endpoint-v2-03.md
@@ -1,0 +1,236 @@
+# cross-peg-in-endpoint-v2-03.clar
+
+- Location: `xlink/packages/contracts/bridge-stacks/contracts/cross-peg-in-endpoint-v2-03.clar`
+- [Deployed contract]()
+
+This technical document provides a detailed overview of the contract responsible for managing the peg-in process, enabling the transfer of assets from external EVM-like blockchains into the Stacks network. The contract serves as the operational interface for relayers to submit orders, which are validated against a threshold of required validators as determined in the `cross-bridge-registry-v2-01`. The contract's primary functionality is implemented through a suite of public functions. Let's review them.
+
+
+## Storage
+### `is-paused`
+| Data     | Type   |
+| -------- | ------ |
+| Variable | `bool` |
+
+A flag indicating whether the peg-in operations are currently active. If set to `true`, all operations are paused, preventing relayers from submitting new peg-in orders. The contract is initialized in a paused state by default.
+
+### `use-whitelist`
+| Data     | Type   |
+| -------- | ------ |
+| Variable | `bool` |
+
+A flag that determines whether the whitelist mechanism is enforced. When set to `true`, only whitelisted users are authorized to perform restricted actions within the contract. By default, this value is `false`.
+
+### `order-hash-to-iter`
+| Data     | Type   |
+| -------- | ------ |
+| Variable | `buff 32` |
+
+A temporary variable used internally to store the hash of the current order being processed.
+
+### `src-chain-id-to-iter`
+| Data     | Type   |
+| -------- | ------ |
+| Variable | `uint` |
+
+A temporary variable used to store the source chain ID of the order currently being processed.
+
+### `whitelisted-users`
+| Data     | Type   |
+| -------- | ------ |
+| Map | `principal bool`|
+
+A map that keeps track of the whitelist status of specific users. Each entry associates a user's principal with a boolean value indicating whether they are authorized to interact with the contract under a whitelist-enabled configuration. If `true`, the user is allowed to perform actions that are otherwise restricted.
+
+### Relevant constants
+
+* `structured-data-prefix`, `message-domain-main`, `message-domain-test`: These constants are utilized in the `validate-order` function to verify the signature consistency with the order hash.
+
+## Features
+
+### Peg-in features
+
+#### `transfer-to-cross`
+This function enables peg-in operations to transfer tokens from an external EVM-like blockchain to Stacks. It validates the provided order by checking its hash and verifying signatures to meet a threshold of validators defined in `cross-bridge-registry-v2-01`. If the order is valid, it mints or transfers the bridged tokens and updates the token reserve for the source EVM chain. It then utilizes `cross-router-v2-02` to route the tokens to the recipient on Stacks or another destination chain. The logic for chain identification is as follows:
+
+```
+chain-id < 1000 // EVM networks
+chain-id == None // Stacks
+```
+
+In the event of validation failure, the function initiates a refund process.
+
+##### Parameters
+```lisp
+(order { 
+        from: (buff 128), 
+        to: (buff 128),
+        token: principal,
+        amount-in-fixed: uint,
+        src-chain-id: uint,
+        dest-chain-id: (optional uint),
+        salt: (buff 256)
+        })
+(token-trait <ft-trait>)
+(signature-packs (list 100 { 
+                            signer: principal,
+                            order-hash: (buff 32),
+                            signature: (buff 65)
+                            }))
+```
+
+#### `transfer-to-cross-swap`
+This function facilitates advanced peg-in operations by incorporating token swapping during cross-chain transfers. It validates the order hash and signatures using `cross-bridge-registry-v2-01`, ensuring compliance with routing configurations, such as token paths and output amounts. Upon successful validation, the bridged tokens are swapped and routed to the recipient using `cross-router-v2-02`, following the same logic outlined in the `transfer-to-cross` feature. If validation fails, the function processes a refund.
+
+##### Parameters
+```lisp
+(order { 
+        from: (buff 128),
+        to: (buff 128),
+        amount-in-fixed: uint,
+        routing-tokens: (list 5 principal),
+        routing-factors: (list 4 uint),
+        min-amount-out-fixed: (optional uint),
+        src-chain-id: uint,
+        dest-chain-id: (optional uint),
+        salt: (buff 256) 
+        })
+(routing-traits (list 5 <ft-trait>))
+(signature-packs (list 100 {
+                            signer: principal,
+                            order-hash: (buff 32),
+                            signature: (buff 65)
+                            }))
+```
+
+#### `transfer-to-launchpad`
+This function enables peg-in operations linked to launchpad projects. It validates the order and signatures through `cross-bridge-registry-v2-01` and confirms compatibility with the launchpad parameters. Once validated, the function mints bridged tokens, transfers them to the recipient, and registers the operation in the `alex-launchpad-v2-01` contract. In case of validation failure, a refund is processed.
+
+##### Parameters
+```lisp
+(order { 
+        address: (buff 128),
+        chain-id: uint,
+        launch-id: uint,
+        dest: (buff 128),
+        token: principal,
+        amount-in-fixed: uint,
+        salt: (buff 256)
+        })
+(token-trait <ft-trait>)
+(signature-packs (list 100 {
+                            signer: principal,
+                            order-hash: (buff 32),
+                            signature: (buff 65)
+                            }))
+```
+
+### Governance features
+#### `is-dao-or-extension`
+This standard protocol function checks whether a caller (`tx-sender`) is the DAO executor or an authorized extension, delegating the extensions check to the `executor-dao` contract.
+
+#### `is-whitelisted`
+A read-only function that checks whether a specific user is included in the `whitelisted-users` map. It returns `true` if the user is whitelisted; otherwise, it returns `false`.
+
+#### `get-paused`
+A read-only function that checks the operational status of the contract.
+
+#### `set-paused`
+A public function, governed through the `is-dao-or-extension`, that can change the contract's operational status.
+
+##### Parameters
+```lisp
+(paused bool)
+```
+
+#### `apply-whitelist`
+A public function that toggles the use of the whitelist in the contract. When enabled, only users who are on the whitelist are authorized to execute restricted actions within the contract.
+
+##### Parameters
+```lisp
+(new-use-whitelist bool)
+```
+
+#### `whitelist`
+A public function that allows authorized extensions, to add or remove a single user from the whitelist. It updates the `whitelisted-users` map, where the user's principal is mapped to a `bool` value (`true` for accepted users and `false` for denied users).
+
+##### Parameters
+```lisp
+(user principal)
+(whitelisted bool)
+```
+
+#### `whitelist-many`
+A public function that allows to batch add or remove multiple users from the whitelist. This function iteratively calls `whitelist`, which handles the mapping of each user's principal to a bool value in the `whitelisted-users` map.
+
+##### Parameters
+```lisp
+(users (list 2000 principal))
+(whitelisted (list 2000 bool))
+```
+
+#### `execute`
+A public function that deactivates earlier versions of the `cross-peg-in-endpoint` contract and ensures that only the latest version (`cross-peg-in-endpoint-v2-03`) remains active.
+
+##### Parameters
+```lisp
+(sender principal)
+```
+
+### Getters
+#### `get-use-whitelist``
+#### `get-validator-or-fail`
+##### Parameters
+```lisp
+(validator principal)
+```
+#### `get-required-validators`
+#### `get-approved-chain-or-fail`
+##### Parameters
+```lisp
+(src-chain-id uint)
+```
+#### `get-token-reserve-or-default`
+##### Parameters
+```lisp
+(pair { token:principal, chain-id: uint })
+```
+#### `get-min-fee-or-default`
+##### Parameters
+```lisp
+(pair { token:principal, chain-id: uint })
+```
+#### `get-approved-pair-or-fail`
+##### Parameters
+```lisp
+(pair { token:principal, chain-id: uint })
+```
+
+## Contract calls (interactions)
+- `executor-dao`: Calls are made to verify whether a certain contract-caller is designated as an extension.
+- `cross-bridge-registry-v2-01`: This contract is called to validate key components of the peg-in process, such as approved tokens, chain IDs, and relayers. It also handles updates to transaction statuses, token reserves, and validator signatures. 
+- `cross-router-v2-02`: This contract is used to validate routing details and execute cross-chain token transfers and swaps. It ensures that the provided routing tokens and factors align with the transfer requirements, performs swaps through `amm-pool-v2-01` when multiple tokens are involved, validates minimum output amounts, and handles the final routing process for peg-in operations, including cross and cross-swap transactions.
+- `alex-launchpad-v2-01`: This contract is used to validate and register peg-in operations specifically related to launchpad projects on the Stacks network.
+- `token-trait`: In cross peg-in operations (featuring `transfer-to-cross`, `transfer-to-cross-swap`, and `transfer-to-launchpad`) this trait is employed to interact with relevant tokens for obtaining their principals, minting, and executing necessary transfers within the transaction. It is a customized version of Stacks' standard definition for Fungible Tokens (`sip-010`), with support for 8-digit fixed notation.
+- `cross-peg-out-endpoint-v2-01`: This contract is invoked to manage refunds for peg-in operations that failed external validations.
+
+## Errors
+
+| Error Name       | Value         |
+| ---------------- | ------------- |
+| `ERR-NOT-AUTHORIZED` | `(err u1000)` |
+| `ERR-TOKEN-NOT-AUTHORIZED`    | `(err u1001)` |
+| `ERR-DUPLICATE-SIGNATURE` | `(err u1009)` |
+| `ERR-ORDER-HASH-MISMATCH`    | `(err u1010)` |
+| `ERR-INVALID-SIGNATURE`   | `(err u1011)` |
+| `ERR-UKNOWN-RELAYER`   | `(err u1012)` |
+| `ERR-REQUIRED-VALIDATORS`    | `(err u1013)` |
+| `ERR-ORDER-ALREADY-SENT`    | `(err u1014)` |
+| `ERR-PAUSED`    | `(err u1015)` |
+| `ERR-INVALID-VALIDATOR` | `(err u1016)` |
+| `ERR-INVALID-INPUT`    | `(err u1020)` |
+| `ERR-NOT-IN-WHITELIST`    | `(err u1021)` |
+| `ERR-INVALID-TOKEN`    | `(err u1022)` |
+| `ERR-SLIPPAGE`    | `(err u1023)` |
+
+<!-- Documentation Contract Template v0.1.0 -->

--- a/developers/contracts/cross-peg-in-endpoint-v2-03.md
+++ b/developers/contracts/cross-peg-in-endpoint-v2-03.md
@@ -51,14 +51,7 @@ A map that keeps track of the whitelist status of specific users. Each entry ass
 ### Peg-in features
 
 #### `transfer-to-cross`
-This function enables peg-in operations to transfer tokens from an external EVM-like blockchain to Stacks. It validates the provided order by checking its hash and verifying signatures to meet a threshold of validators defined in `cross-bridge-registry-v2-01`. If the order is valid, it mints or transfers the bridged tokens and updates the token reserve for the source EVM chain. It then utilizes `cross-router-v2-02` to route the tokens based on the destination chain. The logic for chain identification is as follows:
-
-```
-chain-id < 1000 // the tokens are routed to an EVM-compatible blockchain.
-chain-id == None // the tokens are sent to the recipient on the Stacks network.
-```
-
-In the event of validation failure, the function initiates a refund process.
+This function enables peg-in operations to transfer tokens from an external EVM-like blockchain to Stacks. It validates the provided order by checking its hash and verifying signatures to meet a threshold of validators defined in `cross-bridge-registry-v2-01`. If the order is valid, it mints or transfers the bridged tokens and updates the token reserve for the source EVM chain. It then utilizes `cross-router-v2-02` to route the tokens based on the destination chain. In the event of validation failure, the function initiates a refund process.
 
 ##### Parameters
 ```lisp

--- a/developers/contracts/cross-peg-in-endpoint-v2-03.md
+++ b/developers/contracts/cross-peg-in-endpoint-v2-03.md
@@ -38,7 +38,7 @@ A temporary variable used to store the source chain ID of the order currently be
 ### `whitelisted-users`
 | Data     | Type   |
 | -------- | ------ |
-| Map | `principal bool`|
+| Map | `principal → bool`|
 
 A map that keeps track of the whitelist status of specific users. Each entry associates a user's principal with a boolean value indicating whether they are authorized to interact with the contract under a whitelist-enabled configuration. If `true`, the user is allowed to perform actions that are otherwise restricted.
 
@@ -51,11 +51,11 @@ A map that keeps track of the whitelist status of specific users. Each entry ass
 ### Peg-in features
 
 #### `transfer-to-cross`
-This function enables peg-in operations to transfer tokens from an external EVM-like blockchain to Stacks. It validates the provided order by checking its hash and verifying signatures to meet a threshold of validators defined in `cross-bridge-registry-v2-01`. If the order is valid, it mints or transfers the bridged tokens and updates the token reserve for the source EVM chain. It then utilizes `cross-router-v2-02` to route the tokens to the recipient on Stacks or another destination chain. The logic for chain identification is as follows:
+This function enables peg-in operations to transfer tokens from an external EVM-like blockchain to Stacks. It validates the provided order by checking its hash and verifying signatures to meet a threshold of validators defined in `cross-bridge-registry-v2-01`. If the order is valid, it mints or transfers the bridged tokens and updates the token reserve for the source EVM chain. It then utilizes `cross-router-v2-02` to route the tokens based on the destination chain. The logic for chain identification is as follows:
 
 ```
-chain-id < 1000 // EVM networks
-chain-id == None // Stacks
+chain-id < 1000 // the tokens are routed to an EVM-compatible blockchain.
+chain-id == None // the tokens are sent to the recipient on the Stacks network.
 ```
 
 In the event of validation failure, the function initiates a refund process.

--- a/developers/contracts/cross-peg-out-endpoint-v2-01.md
+++ b/developers/contracts/cross-peg-out-endpoint-v2-01.md
@@ -1,0 +1,136 @@
+# cross-peg-out-endpoint-v2-01.clar
+
+- Location: `xlink/packages/contracts/bridge-stacks/contracts/cross-peg-out-endpoint-v2-01.clar`
+- [Deployed contract]()
+
+This technical document provides a detailed overview of the contract responsible for managing the peg-out process, enabling the transfer of `SIP-010` bridged tokens from the Stacks network to EVM-compatible blockchain networks as the EVM-based assets. The contract manages token transfers by validating amounts, applying fees, and maintaining a whitelist for authorized users if enabled. During the process, tokens are either burned or transferred (depending on the token's configuration) to a designated address on the EVM chain. The core functionalities of the contract are implemented through a series of public and governance functions, as described below.
+
+## Storage
+### `is-paused`
+| Data     | Type   |
+| -------- | ------ |
+| Variable | `bool` |
+
+A flag that indicates whether the peg-out process is active. If set to `true`, all peg-out operations are paused, preventing any new transactions. The contract is deployed in a paused state by default.
+
+### `use-whitelist`
+| Data     | Type   |
+| -------- | ------ |
+| Variable | `bool` |
+
+A flag that determines whether a whitelist is enforced for peg-out operations. If set to `true`, only addresses explicitly whitelisted can execute peg-out transactions. By default, this feature is disabled.
+
+### `whitelisted-users`
+| Data     | Type   |
+| -------- | ------ |
+| Variable | `principal` `bool` |
+
+This map stores the whitelist status of users. Each entry associates a `principal` with a boolean value indicating whether they are authorized to perform peg-out transactions. If `true`, the user is whitelisted; otherwise, they are not permitted to participate in the process.
+
+## Features
+
+### Peg-out feature
+
+#### `transfer-to-unwrap`
+This function manages the peg-out process, enabling users to transfer `SIP-010` bridged tokens from the Stacks network to EVM-compatible blockchains. It begins by validating the transfer through the `validate-transfer-to-unwrap` function, performing checks such as token and chain approval, whitelist status, amount thresholds, and sufficient reserves for the operation.
+Once validated, the function calculates the required fee and determines the net amount to be transferred. Depending on the token's properties, the function either burns the net amount directly from the user's balance or transfers the entire amount (including the fee) to the `cross-bridge-registry-v2-01`.
+At the end of the process, the function logs key destination details, including the `settle-address`, which represents the recipient's address on the EVM-compatible blockchain.
+
+##### Parameters
+```lisp
+(token-trait <ft-trait>)
+(amount-in-fixed uint) 
+(dest-chain-id uint) 
+(settle-address (buff 256))
+```
+
+### Governance features
+#### `is-dao-or-extension`
+This standard protocol function checks whether a caller (`tx-sender`) is the DAO executor or an authorized extension, delegating the extensions check to the `executor-dao` contract.
+
+#### `is-whitelisted`
+A read-only function that checks whether a specific user is included in the `whitelisted-users` map. It returns `true` if the user is whitelisted; otherwise, it returns `false`.
+
+##### Parameters
+```lisp
+(user principal)
+```
+
+#### `get-paused`
+A read-only function that checks the operational status of the contract.
+
+#### `set-paused`
+A public function, governed through the `is-dao-or-extension`, that can change the contract's operational status.
+
+##### Parameters
+```lisp
+(paused bool)
+```
+
+#### `apply-whitelist`
+A public function, governed through the `is-dao-or-extension`, that enables or disables the whitelist mechanism for peg-out transactions. When enabled, only users listed in the `whitelisted-users` map can perform peg-out operations.
+
+##### Parameters
+```lisp
+(new-use-whitelist bool)
+```
+
+#### `whitelist`
+A public function, governed through the `is-dao-or-extension`, that allows the DAO to manage user access to the peg-out feature. It updates the `whitelisted-users` map to either include or remove a specific user. If the `whitelisted` parameter is set to `true`, the user is added to the whitelist; if set to `false`, the user is removed.
+
+##### Parameters
+```lisp
+(user principal)
+(whitelisted bool)
+```
+
+#### `whitelist-many`
+A public function, governed through the `is-dao-or-extension`, that allows the DAO to update the whitelist for multiple users in a single call. It works as a batch operation for the `whitelist` function, applying the specified whitelist status (`true` to add or `false` to remove) for each user in the provided list. The `whitelisted-users` map is updated.
+
+##### Parameters
+```lisp
+(users (list 2000 principal))
+(whitelisted (list 2000 bool))
+```
+
+### Getters
+
+#### `get-use-whitelist`
+#### `get-approved-chain-or-fail`
+##### Parameters
+```lisp
+(dest-chain-id uint)
+```
+#### `get-token-reserve-or-default`
+##### Parameters
+```lisp
+(pair { token: principal, chain-id: uint })
+```
+#### `get-min-fee-or-default`
+##### Parameters
+```lisp
+(pair { token: principal, chain-id: uint })
+```
+#### `get-approved-pair-or-fail`
+##### Parameters
+```lisp
+(pair { token: principal, chain-id: uint })
+```
+
+## Contract calls (interactions)
+- `executor-dao`: Calls are made to verify whether a certain contract-caller is designated as an extension.
+- `cross-bridge-registry-v2-01`: This contract is called to verify key components of the peg-out process. It validates approved tokens and chain pairings, manages the deduction and queries of token reserves, and records accrued fees. It also handles updates to transaction statuses.
+- `token-trait`: In the cross-peg-out process, this trait is employed to manage token operations such as burning tokens when required or transferring them to the `cross-bridge-registry-v2-01` contract. It is a customized version of Stacks' standard definition for Fungible Tokens (`sip-010`), with support for 8-digit fixed notation.
+
+## Errors
+
+| Error Name       | Value         |
+| ---------------- | ------------- |
+| `ERR-NOT-AUTHORIZED` | `(err u1000)` |
+| `ERR-PAUSED`    | `(err u1015)` |
+| `ERR-USER-NOT-WHITELISTED` | `(err u1016)` |
+| `ERR-AMOUNT-LESS-THAN-MIN-FEE`    | `(err u1017)` |
+| `ERR-INVALID-AMOUNT`   | `(err u1019)` |
+
+
+<!-- Documentation Contract Template v0.1.0 -->

--- a/developers/contracts/cross-peg-out-endpoint-v2-01.md
+++ b/developers/contracts/cross-peg-out-endpoint-v2-01.md
@@ -23,9 +23,9 @@ A flag that determines whether a whitelist is enforced for peg-out operations. I
 ### `whitelisted-users`
 | Data     | Type   |
 | -------- | ------ |
-| Variable | `principal` `bool` |
+| Map | `principal → bool` |
 
-This map stores the whitelist status of users. Each entry associates a `principal` with a boolean value indicating whether they are authorized to perform peg-out transactions. If `true`, the user is whitelisted; otherwise, they are not permitted to participate in the process.
+This map stores the whitelist status of users. Each entry associates a `principal` with a boolean value indicating whether they are authorized to perform peg-out transactions. When `use-whitelist` is set to `true`, users with a value of `true` in this map are whitelisted and permitted to participate in the process; otherwise, the whitelist is not enforced.
 
 ## Features
 

--- a/developers/contracts/meta-peg-out-endpoint-v2-03.md
+++ b/developers/contracts/meta-peg-out-endpoint-v2-03.md
@@ -89,7 +89,7 @@ Key validations include:
 - The request must exist.
 - The token pair must be approved and operational (not paused for peg-out).
 - The transaction cannot be indexed to a time before the contract deployment.
-- The transaction's metaprotocol token (BRC-20) must match the requested details (`tick` and `amount`). Additionally, the `from` address must correspond to the `fulfilled-by address`, and the `to` address must match the `peg-out-address`.
+- The transaction's metaprotocol token (BRC-20) must match the requested details (`tick` and `amount`). Additionally, the `from` address must correspond to the `fulfilled-by` address, and the `to` address must match the `peg-out-address`.
 - The request must not be revoked or already finalized.
 
 The procedure is as follows, based on who finalizes it:

--- a/developers/contracts/meta-peg-out-endpoint-v2-03.md
+++ b/developers/contracts/meta-peg-out-endpoint-v2-03.md
@@ -1,0 +1,242 @@
+# meta-peg-out-endpoint-v2-03.clar
+
+- Location: `xlink/packages/contracts/bridge-stacks/contracts/meta-peg-out-endpoint-v2-03.clar`
+- [Deployed contract]()
+
+This technical document provides a detailed overview of the contract responsible for facilitating the peg-out process of tokens from the Stacks network to the burn blockchain. The target token standard is BRC-20, a protocol on Bitcoin's metaprotocol layer that supports fungible assets, inspired by Ethereum's ERC-20 standard.
+
+Unlike the meta-peg-in contract, the meta-peg-out feature is specifically designed to support the bridging-out process. This is achieved through a series of public functions, each intended to execute sequentially, while incorporating grace periods between their execution. In the following sections, we will explore these functions in detail.
+
+## Storage
+
+### `paused`
+
+| Data     | Type   |
+| -------- | ------ |
+| Variable | `bool` |
+
+This data variable serves as a flag to control the operational status of the contract within the system. When set to 'paused,' it blocks all peg-out transactions. By default, the contract is deployed in 'paused' mode. Refer to the [pause](meta-peg-out-endpoint-v2-03.md#pause) governance feature to change this status.
+
+### `fee-to-address`
+
+| Data     | Type   |
+| -------- | ------ |
+| Variable | `principal` |
+
+This variable represents the address to which fees are paid. In this contract, there are two categories of fees: peg-out fees and gas fees. Peg-out fees are transactioned with the relevant token, while gas fees are handled using the Bridged BTC token (`token-abtc`). For more details on these transactions, refer to the [finalize peg-out feature](meta-peg-out-endpoint-v2-03.md#finalize-peg-out-on-index). By default, the address assigned to receive these fees is the `tx-sender` (the original deployer of the contract).
+
+### Relevant constants
+
+#### `burn-height-start`
+
+| Type   | Value |
+| ------ | ----- |
+| `uint` | `burn-block-height` |
+
+This constant specifies the block height of the underlying burn blockchain at the time of contract deployment. It is utilized to ensure that operations within the `finalize-peg-out` function are limited to transactions minted from this block onward.
+
+## Features
+
+### Peg-out features
+
+The peg-out feature is a multi-step process comprising several phases to ensure secure and orderly transactions. The process begins with requesting a peg-out to initiate the transfer of tokens out of the Stacks network. Following this request, configured grace periods allow for specific actions: users can choose to revoke their request or claim it. Once a peg-out request is claimed, the final step is to complete the transaction by finalizing the peg-out.
+
+#### `request-peg-out`
+
+The first step in the peg-out process is to submit a request. This operation involves the `tx-sender` (requester) initiating a peg-out request for a specified amount of a pegged-in token. Upon initiation, the net amount along with fee costs are escrowed by transferring the token and the gas fee token (`token-abtc`) to the contract. These are held until the request is either finalized or revoked.
+
+To proceed, the request must satisfy several validations:
+
+- The pair (token + chain-id) must be approved in the meta registry.
+- The specified amount must exceed the peg-out operation fee for that particular token.
+- The token peg-out operation must be active in the registry (not paused).
+
+Once these validations are met, the operation is registered in the meta registry via the contract `meta-bridge-registry-v2-03`. The function then generates a unique identifier for the request, known as the `request-id`, ensuring traceability and reference for future operations.
+
+##### Parameters
+
+```lisp
+(amount uint)
+(peg-out-address (buff 128))
+(token-trait <ft-trait>)
+(the-chain-id uint)
+```
+
+#### `claim-peg-out`
+
+Following the peg-out request, the next potential step is for the `tx-sender` (claimer) to claim the request. This step is critical, as it marks the request as ready for finalization. This action is executed by calling the function with the `request-id`, along with the `fulfilled-by` parameter, which designates the address responsible for executing the burn blockchain operation.
+
+The claim must satisfy the following validations:
+
+- The request must exist.
+- The token pair must be approved and operational (not paused for peg-out).
+- The request must not be revoked, finalized, or previously claimed.
+
+Once these conditions are met, the final step is to register the claim in the meta registry. This registration includes the claimer, the fulfilled-by address, and the calculated grace period, during which the claimed request will be eligible for finalization.
+
+##### Parameters
+
+```lisp
+(request-id uint)
+(fulfilled-by (buff 128))
+```
+
+#### `finalize-peg-out-on-index`
+
+Finalizing a peg-out is the final step in committing the peg-out process. This function takes in the burn blockchain transaction (Bitcoin) that corresponds to the Stacks layer operation and executes the peg-out request (`request-id`) along with all related token transfers and their corresponding fees. The finalization can be performed by either a peg-in address or a third-party address.
+
+Key validations include:
+- The request must exist.
+- The token pair must be approved and operational (not paused for peg-out).
+- The transaction cannot be indexed to a time before the contract deployment.
+- The transaction's metaprotocol token (BRC-20) must match the requested details (`tick`, `amount`), with `from` and `to` addresses aligning with the fulfilled-by (registered by the claimer) and the peg-out-address (initiated by the requester) respectively.
+- The request must not be revoked or already finalized.
+
+The procedure proceeds as follows based on who finalizes it:
+
+1) Peg-In Address
+    - The net amount of the peg-in token requested is burned from the contract balance, affecting the overall total supply.
+    - The peg-out fee (involved token) and gas fees (`token-abtc`) are paid to the [configured address](meta-peg-out-endpoint-v2-03.md#fee-to-address).
+
+2) Third-Party Address
+    - The net amount of the peg-in token and the burn blockchain gas fee are transferred from the contract to the claimer, so the overall involved token balance remains unaffected.
+    - The peg-out fee is transferred from the contract to the [configured address](meta-peg-out-endpoint-v2-03.md#fee-to-address).
+
+This operation involves indexing the specified transaction through the `oracle-v2-01` contract and marking the request as "finalized" in the `meta-bridge-registry-v2-03` contract.
+
+##### Parameters
+
+```lisp
+(request-id uint)
+(tx {
+      bitcoin-tx: (buff 32768),
+      output: uint,
+      tick: (string-utf8 256),
+      amt: uint,
+      from: (buff 128),
+      to: (buff 128),
+      from-bal: uint,
+      to-bal: uint,
+      decimals: uint
+    })
+(block { header: (buff 80), height: uint })
+(proof { tx-index: uint, hashes: (list 14 (buff 32)), tree-depth: uint })
+(signature-packs (list 10 { signer: principal, tx-hash: (buff 32), signature: (buff 65) }))
+(token-trait <ft-trait>)
+```
+
+#### `revoke-peg-out`
+
+In certain scenarios, a requested peg-out may need to be revoked, allowing users to retract their request if necessary.
+
+Key validations include:
+
+- The grace period must have elapsed.
+- The request must not have been claimed, finalized, or previously revoked.
+
+If these conditions are met, the process continues by returning the tokens initially escrowed for the request, including both the peg-in tokens and the associated fees. These returns are made from the contract directly back to the requester. Finally, the `meta-bridge-registry-v2-03` contract is invoked to mark this request as `revoked`.
+
+##### Parameters
+
+```lisp
+(request-id uint)
+(token-trait <ft-trait>)
+```
+
+### Supporting features
+
+The following functions are tools to assist the off-chain activities.
+
+1. Validation helpers (`validate-peg-out`).
+2. Token pair helpers (`get-pair-details-many`).
+
+### Governance features
+
+#### `is-dao-or-extension`
+
+This standard protocol function checks whether a caller (`tx-sender`) is the DAO executor or an authorized extension, delegating the extensions check to the `executor-dao` contract.
+
+#### `is-paused`
+
+A read-only function that checks the operational status of the contract.
+
+#### `pause`
+
+A public function, governed through the `is-dao-or-extension`, that can change the contract's operational status.
+
+##### Parameters
+
+```lisp
+(new-paused bool)
+```
+
+#### `transfer-all-to-many`
+
+This contract feature is designed to transfer its entire balance of a specified list of tokens to a new owner. Access to this feature is restricted by the `is-dao-or-extension` function.
+
+##### Parameters
+
+```lisp
+(new-owner principal) (token-traits (list 10 <ft-trait>))
+```
+
+#### `set-fee-to-address`
+
+This contract feature allows for specifying the address to which peg-out fees (denominated in the relevant tokens) and gas fees (denominated in Bridged BTC tokens, known as `token-abtc`) will be transferred.
+
+##### Parameters
+
+```lisp
+(new-fee-to-address principal)
+```
+
+### Getters
+
+* `get-fee-to-address`
+* `get-request`
+* `get-request-many`
+* `get-request-revoke-grace-period`
+* `get-request-claim-grace-period`
+* `get-request-or-fail`
+* `get-pair-details`
+* `get-pair-details-many`
+* `get-pair-details-or-fail`
+* `get-tick-to-pair-or-fail`
+* `get-peg-in-sent-or-default`
+
+### Relevant internal functions
+
+* `index-tx`
+
+## Contract calls (interactions)
+
+* `executor-dao`: Calls are made to verify whether a certain contract-caller is designated as an extension.
+* `meta-bridge-registry-v2-03`: This interaction is primarily utilized by the peg-out contract to register request operations. Additionally, this contract is responsible for managing approved addresses. It provides functionality through its `is-peg-in-address-approved` and `is-fulfill-address-approved` functions, which verify whether specific addresses are authorized within the system.
+* `oracle-v2-01`: This contract is called to verify that a transaction was mined and to index Bitcoin transactions.
+* Tokens (`token-trait`) During the steps of peg-out operations, this trait is utilized to invoke the relevant tokens and execute the necessary transfers involved in the transaction. It is a customized adaptation of Stacks' standard definition for Fungible Tokens (`sip-010`), with additional support for 8-digit fixed-point notation.
+* `token-abtc`: This is the Bridged BTC token used throughout the peg-out contract to operate with native Stacks' SIP-010 token transactions involving the burn blockchain base-coin (BTC).
+
+## Errors
+
+| Error Name                        | Value         |
+| --------------------------------- | ------------- |
+| `err-unauthorised`                | `(err u1000)` |
+| `err-paused`                      | `(err u1001)` |
+| `err-peg-in-address-not-found`    | `(err u1002)` |
+| `err-invalid-amount`              | `(err u1003)` |
+| `err-token-mismatch`              | `(err u1004)` |
+| `err-invalid-tx`                  | `(err u1005)` |
+| `err-already-sent`                | `(err u1006)` |
+| `err-address-mismatch`            | `(err u1007)` |
+| `err-request-already-revoked`     | `(err u1008)` |
+| `err-request-already-finalized`   | `(err u1009)` |
+| `err-revoke-grace-period`         | `(err u1010)` |
+| `err-request-already-claimed`     | `(err u1011)` |
+| `err-invalid-input`               | `(err u1012)` |
+| `err-tx-mined-before-request`     | `(err u1013)` |
+| `err-commit-tx-mismatch`          | `(err u1014)` |
+| `err-invalid-burn-height`         | `(err u1003)` |
+| `err-tx-mined-before-start`       | `(err u1015)` |
+
+
+<!-- Documentation Contract Template v0.1.0 -->

--- a/developers/contracts/meta-peg-out-endpoint-v2-03.md
+++ b/developers/contracts/meta-peg-out-endpoint-v2-03.md
@@ -23,7 +23,7 @@ This data variable serves as a flag to control the operational status of the con
 | -------- | ------ |
 | Variable | `principal` |
 
-This variable represents the address to which fees are paid. In this contract, there are two categories of fees: peg-out fees and gas fees. Peg-out fees are transactioned with the relevant token, while gas fees are handled using the Bridged BTC token (`token-abtc`). For more details on these transactions, refer to the [finalize peg-out feature](meta-peg-out-endpoint-v2-03.md#finalize-peg-out-on-index). By default, the address assigned to receive these fees is the `tx-sender` (the original deployer of the contract).
+This variable represents the address to which fees are paid. In this contract, there are two categories of fees: peg-out fees and gas fees. Peg-out fees are transactioned with the relevant token, while gas fees are handled using the Bridged BTC token (`token-abtc`). For more details on these transactions, refer to the [finalize peg-out feature](meta-peg-out-endpoint-v2-03.md#finalize-peg-out-on-index). By default, the address assigned to receive these fees is the `tx-sender` address of the contract deployer.
 
 ### Relevant constants
 
@@ -64,7 +64,7 @@ Once these validations are met, the operation is registered in the meta registry
 
 #### `claim-peg-out`
 
-Following the peg-out request, the next potential step is for the `tx-sender` (claimer) to claim the request. This step is critical, as it marks the request as ready for finalization. This action is executed by calling the function with the `request-id`, along with the `fulfilled-by` parameter, which designates the address responsible for executing the burn blockchain operation.
+Following the peg-out request, a next potential step is to claim the request. This step is critical, as it marks the request as ready for finalization. This action is executed by calling the function with the `request-id` of the previously created request, along with the `fulfilled-by` parameter, which designates the address responsible for executing the burn blockchain operation.
 
 The claim must satisfy the following validations:
 
@@ -89,10 +89,10 @@ Key validations include:
 - The request must exist.
 - The token pair must be approved and operational (not paused for peg-out).
 - The transaction cannot be indexed to a time before the contract deployment.
-- The transaction's metaprotocol token (BRC-20) must match the requested details (`tick`, `amount`), with `from` and `to` addresses aligning with the fulfilled-by (registered by the claimer) and the peg-out-address (initiated by the requester) respectively.
+- The transaction's metaprotocol token (BRC-20) must match the requested details (`tick` and `amount`). Additionally, the `from` address must correspond to the `fulfilled-by address`, and the `to` address must match the `peg-out-address`.
 - The request must not be revoked or already finalized.
 
-The procedure proceeds as follows based on who finalizes it:
+The procedure is as follows, based on who finalizes it:
 
 1) Peg-In Address
     - The net amount of the peg-in token requested is burned from the contract balance, affecting the overall total supply.


### PR DESCRIPTION
## Description 

Added xLINK contract technical documents. Impacts on https://docs.xlink.network/. This branch is live at a temporary URL [here ](https://coinfabrik.gitbook.io/xlink-docs/xlink-contracts-w3).

### Changes

1. Added technical documentation for the contracts:
    
    - `cross-peg-in-endpoint-v2-03.clar`
    - `cross-peg-out-endpoint-v2-01.clar`
    
2. Updated the `SUMMARY.md` accordingly. 

PLEASE FIRST MERGE PR https://github.com/xlink-network/xlink-docs/pull/7.

### Following work

- Index page and comprehensive overview for the technical documentation of contracts.
- Design refinements to accommodate the new sections on GitBook.